### PR TITLE
Simplify and improve exceptions

### DIFF
--- a/src/py_openocd_client/__init__.py
+++ b/src/py_openocd_client/__init__.py
@@ -2,10 +2,10 @@
 
 from .client import PyOpenocdClient  # noqa: F401
 from .errors import (  # noqa: F401
-    OcdCommandError,
-    OcdCommandInvalidResponse,
-    OcdCommandTimeout,
+    OcdBaseException,
+    OcdCommandFailedError,
+    OcdCommandTimeoutError,
     OcdConnectionError,
-    OcdError,
+    OcdInvalidResponseError,
 )
 from .types import BpInfo, BpType, OcdCommandResult, WpInfo, WpType  # noqa: F401

--- a/src/py_openocd_client/bp_parser.py
+++ b/src/py_openocd_client/bp_parser.py
@@ -3,6 +3,7 @@
 import re
 from typing import Optional
 
+from .errors import _OcdParsingError
 from .types import BpInfo, BpType
 
 
@@ -37,7 +38,7 @@ class _BpParser:
                 # Successfully parsed item
                 return bp_info
 
-        raise ValueError(
+        raise _OcdParsingError(
             "Could not parse this entry from the 'bp' command output: " + line
         )
 

--- a/src/py_openocd_client/client.py
+++ b/src/py_openocd_client/client.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional, Tuple, Type
 
 from .baseclient import _PyOpenocdBaseClient
 from .bp_parser import _BpParser
-from .errors import OcdCommandError, OcdCommandInvalidResponse
+from .errors import OcdCommandFailedError, OcdInvalidResponseError, _OcdParsingError
 from .types import BpInfo, OcdCommandResult, WpInfo, WpType
 from .wp_parser import _WpParser
 
@@ -70,16 +70,18 @@ class PyOpenocdClient:
 
         raw_result = self.raw_cmd(full_cmd, timeout=timeout)
 
-        # Verify the raw output has the expected format, which can be one of:
-        # - command return code (positive or negative decimal number) and that's it
-        # - or command return code (positive or negative decimal number) followed by
-        #   a space character and optionally the command output
+        # Verify the raw output of the has the expected format. It can be:
+        #
+        # - Command return code (positive or negative decimal number) and that's it.
+        #
+        # - Or, command return code (positive or negative decimal number) followed by
+        #   a space character and optionally the command's textual output.
         if re.match(r"^-?\d+($| )", raw_result) is None:
-            raise OcdCommandInvalidResponse(
+            msg = (
                 "Received unexpected response from OpenOCD. "
                 "It looks like OpenOCD misbehaves. "
-                "The response was: " + repr(raw_result)
             )
+            raise OcdInvalidResponseError(msg, full_cmd, raw_result)
 
         raw_result_parts = raw_result.split(" ", maxsplit=1)
         assert len(raw_result_parts) in [1, 2]
@@ -89,7 +91,7 @@ class PyOpenocdClient:
         result = OcdCommandResult(cmd=cmd, full_cmd=full_cmd, retcode=retcode, out=out)
 
         if throw and result.retcode != 0:
-            raise OcdCommandError(result)
+            raise OcdCommandFailedError(result)
 
         return result
 
@@ -129,8 +131,16 @@ class PyOpenocdClient:
     def get_reg(self, reg_name: str, force: bool = False) -> int:
         force_arg = "-force " if force else ""
         cmd = f"dict get [ get_reg {force_arg}{reg_name} ] {reg_name}"
-        reg_value = self.cmd(cmd).out.strip()
-        return int(reg_value, 0)
+
+        result = self.cmd(cmd)
+        reg_value = result.out.strip()
+
+        try:
+            # Expecting a single hexadecimal number on the output
+            return int(reg_value, 16)
+        except ValueError as e:
+            msg = "Obtained invalid number from get_reg command"
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out) from e
 
     def set_reg(self, reg_name: str, reg_value: int, force: bool = False) -> None:
         force_arg = "-force " if force else ""
@@ -155,6 +165,9 @@ class PyOpenocdClient:
         phys: bool = False,
         timeout: Optional[float] = None,
     ) -> List[int]:
+        # FIXME: Change the type annotation of "bit_width" to "Literal[8, 16, 32, 64]"
+        # once support of Python 3.7 is dropped.
+
         self._check_memory_access_params(addr, bit_width)
         if count < 1:
             raise ValueError("Count must be 1 or higher")
@@ -162,24 +175,24 @@ class PyOpenocdClient:
         cmd = f"read_memory {hex(addr)} {bit_width} {count}"
         if phys:
             cmd += " phys"
-        out = self.cmd(cmd, timeout=timeout).out.strip()
+        result = self.cmd(cmd, timeout=timeout)
+        out = result.out.strip()
 
         values_str = out.split(" ")
 
         # Safety validation of the command output
         if len(values_str) != count:
-            raise ValueError(
+            msg = (
                 "OpenOCD's read_memory command provided different number of values "
                 f"than requested (expected {count} but obtained {len(values_str)})."
             )
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out)
 
         # Safety validation, cont'd
         hex_regex = r"^0x[0-9a-fA-F]+$"
         if any(re.match(hex_regex, v) is None for v in values_str):
-            raise ValueError(
-                "Unexpected output from OpenOCD's read_memory command - "
-                "found an item that is not a valid hexadecimal number"
-            )
+            msg = "Found an item that is not a valid hexadecimal number"
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out)
 
         # str -> int
         values = [int(v, 16) for v in values_str]
@@ -206,6 +219,9 @@ class PyOpenocdClient:
         phys: bool = False,
         timeout: Optional[float] = None,
     ) -> None:
+        # FIXME: Change the type annotation of "bit_width" to "Literal[8, 16, 32, 64]"
+        # once support of Python 3.7 is dropped.
+
         self._check_memory_access_params(addr, bit_width)
         self._check_memory_write_values(values, bit_width)
 
@@ -215,9 +231,13 @@ class PyOpenocdClient:
         self.cmd(cmd, timeout=timeout).out.strip()
 
     def list_bp(self) -> List[BpInfo]:
-        out = self.cmd("bp").out.strip()
-        bp_lines = out.splitlines()
-        return [_BpParser.parse_bp_entry(line) for line in bp_lines]
+        result = self.cmd("bp")
+        bp_lines = result.out.strip().splitlines()
+        try:
+            return [_BpParser.parse_bp_entry(line) for line in bp_lines]
+        except _OcdParsingError as e:
+            msg = "Could not parse the output of 'bp' command"
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out) from e
 
     def add_bp(self, addr: int, size: int, hw: bool = False) -> None:
         cmd = "bp " + hex(addr) + " " + str(size)
@@ -232,9 +252,13 @@ class PyOpenocdClient:
         self.cmd("rbp all")
 
     def list_wp(self) -> List[WpInfo]:
-        out = self.cmd("wp").out.strip()
-        wp_lines = out.splitlines()
-        return [_WpParser().parse_wp_entry(line) for line in wp_lines]
+        result = self.cmd("wp")
+        wp_lines = result.out.splitlines()
+        try:
+            return [_WpParser().parse_wp_entry(line) for line in wp_lines]
+        except _OcdParsingError as e:
+            msg = "Could not parse the output of 'wp' command"
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out) from e
 
     def add_wp(self, addr: int, size: int, wp_type: WpType = WpType.ACCESS) -> None:
         cmd = "wp " + hex(addr) + " " + str(size) + " " + str(wp_type.value)
@@ -253,15 +277,14 @@ class PyOpenocdClient:
         return self.cmd("version").out.strip()
 
     def version_tuple(self) -> Tuple[int, int, int]:
-        version_str = self.version()
-        version_regex = r"Open On\-Chip Debugger (\d+)\.(\d+)\.(\d+)"
+        result = self.cmd("version")
+        version_str = result.out.strip()
 
+        version_regex = r"Open On\-Chip Debugger (\d+)\.(\d+)\.(\d+)"
         match = re.search(version_regex, version_str)
         if match is None:
-            raise ValueError(
-                "Unable to parse the version string received "
-                "from OpenOCD: {version_str}"
-            )
+            msg = "Unable to parse the version string received from OpenOCD"
+            raise OcdInvalidResponseError(msg, result.full_cmd, result.out)
 
         major = int(match.group(1))
         minor = int(match.group(2))
@@ -282,7 +305,7 @@ class PyOpenocdClient:
         self.disconnect()
 
     def shutdown(self) -> None:
-        self.cmd(
-            "shutdown", throw=False
-        )  # OpenOCD's shutdown command returns a non-zero error code
+        # OpenOCD's shutdown command returns a non-zero error code (which is expected).
+        # For that reason, throw=False is used.
+        self.cmd("shutdown", throw=False)
         self.disconnect()

--- a/src/py_openocd_client/errors.py
+++ b/src/py_openocd_client/errors.py
@@ -3,7 +3,7 @@
 from .types import OcdCommandResult
 
 
-class OcdError(RuntimeError):
+class OcdBaseException(Exception):
     """
     Base class for exceptions of PyOpenocdClient.
     """
@@ -11,7 +11,7 @@ class OcdError(RuntimeError):
     pass
 
 
-class OcdCommandError(OcdError):
+class OcdCommandFailedError(OcdBaseException):
     """
     Exception denoting a TCL command that ended unsuccessfully.
     """
@@ -27,13 +27,50 @@ class OcdCommandError(OcdError):
         return self._result
 
 
-class OcdConnectionError(OcdError):
+class OcdCommandTimeoutError(OcdBaseException):
+    def __init__(self, msg: str, full_cmd: str, timeout: float):
+        self._full_cmd = full_cmd
+        self._timeout = timeout
+        super().__init__(msg)
+
+    @property
+    def full_cmd(self) -> str:
+        return self._full_cmd
+
+    @property
+    def timeout(self) -> float:
+        return self._timeout
+
+
+class OcdInvalidResponseError(OcdBaseException):
+    """
+    Exception which means that a TCL command produced unexpected output. That is,
+    PyOpenocdClient could not understand the output form OpenOCD and parse it.
+    """
+
+    def __init__(self, msg: str, full_cmd: str, out: str):
+        self._full_cmd = full_cmd
+        self._out = out
+        super().__init__(msg)
+
+    @property
+    def full_cmd(self) -> str:
+        return self._full_cmd
+
+    @property
+    def out(self) -> str:
+        return self._out
+
+
+class OcdConnectionError(OcdBaseException):
     pass
 
 
-class OcdCommandTimeout(OcdError):
-    pass
+class _OcdParsingError(OcdBaseException):
+    """
+    Internal exception that denotes parsing error.
 
+    Not part of the public API. May change between versions.
+    """
 
-class OcdCommandInvalidResponse(OcdError):
     pass

--- a/src/py_openocd_client/errors.py
+++ b/src/py_openocd_client/errors.py
@@ -28,17 +28,23 @@ class OcdCommandFailedError(OcdBaseException):
 
 
 class OcdCommandTimeoutError(OcdBaseException):
-    def __init__(self, msg: str, full_cmd: str, timeout: float):
-        self._full_cmd = full_cmd
+    def __init__(self, msg: str, raw_cmd: str, timeout: float):
+        self._raw_cmd = raw_cmd
         self._timeout = timeout
         super().__init__(msg)
 
     @property
-    def full_cmd(self) -> str:
-        return self._full_cmd
+    def raw_cmd(self) -> str:
+        """
+        Raw command that did not complete within the timeout.
+        """
+        return self._raw_cmd
 
     @property
     def timeout(self) -> float:
+        """
+        Timeout value which got exceeded.
+        """
         return self._timeout
 
 
@@ -48,17 +54,23 @@ class OcdInvalidResponseError(OcdBaseException):
     PyOpenocdClient could not understand the output form OpenOCD and parse it.
     """
 
-    def __init__(self, msg: str, full_cmd: str, out: str):
-        self._full_cmd = full_cmd
+    def __init__(self, msg: str, raw_cmd: str, out: str):
+        self._raw_cmd = raw_cmd
         self._out = out
         super().__init__(msg)
 
     @property
-    def full_cmd(self) -> str:
-        return self._full_cmd
+    def raw_cmd(self) -> str:
+        """
+        Raw command that produced the invalid response.
+        """
+        return self._raw_cmd
 
     @property
     def out(self) -> str:
+        """
+        The actual response which could not be understood and parsed.
+        """
         return self._out
 
 

--- a/src/py_openocd_client/types.py
+++ b/src/py_openocd_client/types.py
@@ -13,7 +13,7 @@ class OcdCommandResult:
 
     retcode: int
     cmd: str
-    full_cmd: str
+    raw_cmd: str
     out: str
 
 

--- a/src/py_openocd_client/wp_parser.py
+++ b/src/py_openocd_client/wp_parser.py
@@ -2,6 +2,7 @@
 
 import re
 
+from .errors import _OcdParsingError
 from .types import WpInfo, WpType
 
 
@@ -31,7 +32,7 @@ class _WpParser:
 
         match = re.match(new_format, line)
         if match is None:
-            raise ValueError(
+            raise _OcdParsingError(
                 "Could not parse this entry from the 'wp' command output: " + line
             )
 

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -129,7 +129,7 @@ def test_timeout_exceeded(openocd_process):
 
         expected_full_cmd = (
             "set CMD_RETCODE [ catch { sleep 2000 } CMD_OUTPUT ] ; "
-            'return "$CMD_RETCODE $CMD_OUTPUT" ;'
+            'return "$CMD_RETCODE $CMD_OUTPUT" ; '
         )
         assert e.value.full_cmd == expected_full_cmd
         assert e.value.timeout == 1.0

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -127,11 +127,11 @@ def test_timeout_exceeded(openocd_process):
         with pytest.raises(OcdCommandTimeoutError) as e:
             ocd.cmd("sleep 2000", timeout=1.0)
 
-        expected_full_cmd = (
+        expected_raw_cmd = (
             "set CMD_RETCODE [ catch { sleep 2000 } CMD_OUTPUT ] ; "
             'return "$CMD_RETCODE $CMD_OUTPUT" ; '
         )
-        assert e.value.full_cmd == expected_full_cmd
+        assert e.value.raw_cmd == expected_raw_cmd
         assert e.value.timeout == 1.0
 
         # Timeout causes disconnection

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -4,7 +4,11 @@ import time
 
 import pytest
 
-from py_openocd_client import OcdCommandError, OcdCommandTimeout, PyOpenocdClient
+from py_openocd_client import (
+    OcdCommandFailedError,
+    OcdCommandTimeoutError,
+    PyOpenocdClient,
+)
 
 
 def test_basic(openocd_process):
@@ -45,7 +49,7 @@ def test_echo_with_capture(openocd_process):
 
 def test_failed_cmd(openocd_process):
     with PyOpenocdClient() as ocd:
-        with pytest.raises(OcdCommandError) as e:
+        with pytest.raises(OcdCommandFailedError) as e:
             ocd.cmd("some_nonexistent_cmd some_arg")
 
         assert e.value.result.retcode != 0
@@ -63,7 +67,7 @@ def test_failed_cmd_2(openocd_process):
         else:
             expected_retcode = 77
 
-        with pytest.raises(OcdCommandError) as e:
+        with pytest.raises(OcdCommandFailedError) as e:
             ocd.cmd("return -level 0 -code 77 {some text}")
 
         assert e.value.result.retcode == expected_retcode
@@ -80,7 +84,7 @@ def test_failed_cmd_negative_retcode(openocd_process):
         else:
             expected_retcode = -200
 
-        with pytest.raises(OcdCommandError) as e:
+        with pytest.raises(OcdCommandFailedError) as e:
             ocd.cmd("return -level 0 -code -200 {some text}")
 
         assert e.value.result.retcode == expected_retcode
@@ -120,8 +124,11 @@ def test_timeout_ok(openocd_process):
 
 def test_timeout_exceeded(openocd_process):
     with PyOpenocdClient() as ocd:
-        with pytest.raises(OcdCommandTimeout):
+        with pytest.raises(OcdCommandTimeoutError) as e:
             ocd.cmd("sleep 2000", timeout=1.0)
+
+        assert e.value.timeout == 1.0
+        assert e.value.full_cmd == "sleep 2000"
 
         # Timeout causes disconnection
         assert not ocd.is_connected()

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -127,8 +127,12 @@ def test_timeout_exceeded(openocd_process):
         with pytest.raises(OcdCommandTimeoutError) as e:
             ocd.cmd("sleep 2000", timeout=1.0)
 
+        expected_full_cmd = (
+            'set CMD_RETCODE [ catch { sleep 2000 } CMD_OUTPUT ] ; '
+            'return "$CMD_RETCODE $CMD_OUTPUT" ;'
+        )
+        assert e.value.full_cmd == expected_full_cmd
         assert e.value.timeout == 1.0
-        assert e.value.full_cmd == "sleep 2000"
 
         # Timeout causes disconnection
         assert not ocd.is_connected()

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -128,7 +128,7 @@ def test_timeout_exceeded(openocd_process):
             ocd.cmd("sleep 2000", timeout=1.0)
 
         expected_full_cmd = (
-            'set CMD_RETCODE [ catch { sleep 2000 } CMD_OUTPUT ] ; '
+            "set CMD_RETCODE [ catch { sleep 2000 } CMD_OUTPUT ] ; "
             'return "$CMD_RETCODE $CMD_OUTPUT" ;'
         )
         assert e.value.full_cmd == expected_full_cmd

--- a/tests_integration/py_openocd_client/test_integration_raw_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_raw_cmd.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from py_openocd_client import OcdCommandTimeout, PyOpenocdClient
+from py_openocd_client import OcdCommandTimeoutError, PyOpenocdClient
 
 
 def test_no_output(openocd_process):
@@ -87,5 +87,8 @@ def test_raw_cmd_timeout_ok(openocd_process):
 
 def test_raw_cmd_timeout_exceeded(openocd_process):
     with PyOpenocdClient() as ocd:
-        with pytest.raises(OcdCommandTimeout):
+        with pytest.raises(OcdCommandTimeoutError) as e:
             ocd.raw_cmd("sleep 2000", timeout=1.0)
+
+        assert e.value.full_cmd == "sleep 2000"
+        assert e.value.timeout == 1.0

--- a/tests_integration/py_openocd_client/test_integration_raw_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_raw_cmd.py
@@ -90,5 +90,5 @@ def test_raw_cmd_timeout_exceeded(openocd_process):
         with pytest.raises(OcdCommandTimeoutError) as e:
             ocd.raw_cmd("sleep 2000", timeout=1.0)
 
-        assert e.value.full_cmd == "sleep 2000"
+        assert e.value.raw_cmd == "sleep 2000"
         assert e.value.timeout == 1.0

--- a/tests_unit/py_openocd_client/test_baseclient_errors.py
+++ b/tests_unit/py_openocd_client/test_baseclient_errors.py
@@ -237,7 +237,7 @@ def test_raw_cmd_timeout(socket_inst_mock, use_global_timeout):
             "Did not receive the complete command response " "within 4.5 seconds."
         )
         assert expected_msg in str(e)
-        assert e.value.full_cmd == "my_command"
+        assert e.value.raw_cmd == "my_command"
         assert e.value.timeout == 4.5
 
     assert not ocd_base.is_connected()

--- a/tests_unit/py_openocd_client/test_baseclient_errors.py
+++ b/tests_unit/py_openocd_client/test_baseclient_errors.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from py_openocd_client import OcdCommandTimeout, OcdConnectionError
+from py_openocd_client import OcdCommandTimeoutError, OcdConnectionError
 from py_openocd_client.baseclient import _PyOpenocdBaseClient
 
 _COMMAND_DELIMITER = b"\x1a"
@@ -227,7 +227,7 @@ def test_raw_cmd_timeout(socket_inst_mock, use_global_timeout):
 
         socket_inst_mock.recv.side_effect = chunks_to_receive
 
-        with pytest.raises(OcdCommandTimeout) as e:
+        with pytest.raises(OcdCommandTimeoutError) as e:
             if not use_global_timeout:
                 ocd_base.raw_cmd("my_command", timeout=4.5)
             else:
@@ -237,6 +237,8 @@ def test_raw_cmd_timeout(socket_inst_mock, use_global_timeout):
             "Did not receive the complete command response " "within 4.5 seconds."
         )
         assert expected_msg in str(e)
+        assert e.value.full_cmd == "my_command"
+        assert e.value.timeout == 4.5
 
     assert not ocd_base.is_connected()
 

--- a/tests_unit/py_openocd_client/test_bp_parser.py
+++ b/tests_unit/py_openocd_client/test_bp_parser.py
@@ -4,6 +4,7 @@ import pytest
 
 from py_openocd_client import BpType
 from py_openocd_client.bp_parser import _BpParser
+from py_openocd_client.errors import _OcdParsingError
 
 
 def test_parse_bp_entry_sw():
@@ -86,7 +87,7 @@ def test_parse_bp_entry_error():
     """
 
     malformed_entry = "Software bre__XYZ__k(IVA): addr=0x0, len=0x8, orig_instr=0x1"
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(_OcdParsingError) as e:
         _BpParser.parse_bp_entry(malformed_entry)
 
     assert "Could not parse" in str(e)

--- a/tests_unit/py_openocd_client/test_client.py
+++ b/tests_unit/py_openocd_client/test_client.py
@@ -221,6 +221,7 @@ def test_cmd_negative_retcode(baseclient_inst_mock):
     with pytest.raises(OcdCommandFailedError) as e:
         ocd.cmd("some_cmd")
 
+    assert e.value.result.cmd == "some_cmd"
     assert e.value.result.retcode == -123
     assert e.value.result.out == "some output"
 
@@ -230,11 +231,11 @@ def test_cmd_invalid_responses(baseclient_inst_mock):
 
     baseclient_inst_mock.raw_cmd.return_value = ""
     with pytest.raises(OcdInvalidResponseError) as e:
-        ocd.cmd("cmd")
+        ocd.cmd("some_cmd")
 
     expected_full_cmd = (
         "set CMD_RETCODE [ "
-        "catch { cmd } CMD_OUTPUT ] ; "
+        "catch { some_cmd } CMD_OUTPUT ] ; "
         'return "$CMD_RETCODE $CMD_OUTPUT" ; '
     )
     assert e.value.full_cmd == expected_full_cmd
@@ -242,15 +243,15 @@ def test_cmd_invalid_responses(baseclient_inst_mock):
 
     baseclient_inst_mock.raw_cmd.return_value = "a"
     with pytest.raises(OcdInvalidResponseError):
-        ocd.cmd("cmd")
+        ocd.cmd("some_cmd")
 
     baseclient_inst_mock.raw_cmd.return_value = "abc def"
     with pytest.raises(OcdInvalidResponseError):
-        ocd.cmd("cmd")
+        ocd.cmd("some_cmd")
 
     baseclient_inst_mock.raw_cmd.return_value = "56a some output"
     with pytest.raises(OcdInvalidResponseError) as e:
-        ocd.cmd("cmd")
+        ocd.cmd("some_cmd")
 
     assert e.value.full_cmd == expected_full_cmd
     assert e.value.out == "56a some output"

--- a/tests_unit/py_openocd_client/test_client_commands.py
+++ b/tests_unit/py_openocd_client/test_client_commands.py
@@ -27,7 +27,7 @@ def ocd() -> PyOpenocdClient:
 
 def _prepare_command_result(out) -> OcdCommandResult:
     return OcdCommandResult(
-        retcode="0", cmd="cmd_placeholder", full_cmd="full_cmd_placeholder", out=out
+        retcode="0", cmd="cmd_placeholder", raw_cmd="raw_cmd_placeholder", out=out
     )
 
 
@@ -106,13 +106,13 @@ def test_get_reg_error(ocd):
     ocd.cmd.return_value = _prepare_command_result("0xKLM")
     with pytest.raises(OcdInvalidResponseError) as e:
         ocd.get_reg("ra")
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == "0xKLM"
 
     ocd.cmd.return_value = _prepare_command_result("0x1234 0x5678")
     with pytest.raises(OcdInvalidResponseError) as e:
         ocd.get_reg("pc")
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == "0x1234 0x5678"
 
 
@@ -234,7 +234,7 @@ def test_read_memory_response_errors(ocd):
         ocd.read_memory(0x1234, 16, count=8)
 
     assert "different number of values than requested" in str(e)
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == "0x1111 0x2222 0x3333"
 
     # Pretend that we received an invalid number
@@ -243,7 +243,7 @@ def test_read_memory_response_errors(ocd):
         ocd.read_memory(0x5678, 16, count=2)
 
     assert "not a valid hexadecimal number" in str(e)
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == "0x1111 0xKLM"
 
 
@@ -280,7 +280,7 @@ def test_list_bp_invalid_response(ocd):
 
     ocd.cmd.assert_called_once_with("bp")
 
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == bp_command_output
 
 
@@ -347,7 +347,7 @@ def test_list_wp_invalid_response(ocd):
 
     ocd.cmd.assert_called_once_with("wp")
 
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == wp_command_output
 
 
@@ -413,7 +413,7 @@ def test_version_tuple_error(ocd):
     with pytest.raises(OcdInvalidResponseError) as e:
         ocd.version_tuple()
     assert "Unable to parse the version string received from OpenOCD" in str(e)
-    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.raw_cmd == "raw_cmd_placeholder"
     assert e.value.out == version_str
 
 

--- a/tests_unit/py_openocd_client/test_client_commands.py
+++ b/tests_unit/py_openocd_client/test_client_commands.py
@@ -8,6 +8,7 @@ from py_openocd_client import (
     BpInfo,
     BpType,
     OcdCommandResult,
+    OcdInvalidResponseError,
     PyOpenocdClient,
     WpInfo,
     WpType,
@@ -26,7 +27,7 @@ def ocd() -> PyOpenocdClient:
 
 def _prepare_command_result(out) -> OcdCommandResult:
     return OcdCommandResult(
-        retcode="0", cmd="don't care", full_cmd="don't care", out=out
+        retcode="0", cmd="cmd_placeholder", full_cmd="full_cmd_placeholder", out=out
     )
 
 
@@ -99,6 +100,20 @@ def test_get_reg(ocd):
     ocd.cmd.return_value = _prepare_command_result("0xaaaa")
     assert ocd.get_reg("sp", force=True) == 0xAAAA
     ocd.cmd.assert_called_once_with("dict get [ get_reg -force sp ] sp")
+
+
+def test_get_reg_error(ocd):
+    ocd.cmd.return_value = _prepare_command_result("0xKLM")
+    with pytest.raises(OcdInvalidResponseError) as e:
+        ocd.get_reg("ra")
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == "0xKLM"
+
+    ocd.cmd.return_value = _prepare_command_result("0x1234 0x5678")
+    with pytest.raises(OcdInvalidResponseError) as e:
+        ocd.get_reg("pc")
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == "0x1234 0x5678"
 
 
 def test_set_reg(ocd):
@@ -215,15 +230,21 @@ def test_write_memory_argument_errors(ocd):
 def test_read_memory_response_errors(ocd):
     # Pretend that only 3 values were returned instead of requested 8
     ocd.cmd.return_value = _prepare_command_result("0x1111 0x2222 0x3333")
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(OcdInvalidResponseError) as e:
         ocd.read_memory(0x1234, 16, count=8)
+
     assert "different number of values than requested" in str(e)
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == "0x1111 0x2222 0x3333"
 
     # Pretend that we received an invalid number
     ocd.cmd.return_value = _prepare_command_result("0x1111 0xKLM")
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(OcdInvalidResponseError) as e:
         ocd.read_memory(0x5678, 16, count=2)
+
     assert "not a valid hexadecimal number" in str(e)
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == "0x1111 0xKLM"
 
 
 def test_list_bp_empty(ocd):
@@ -245,6 +266,22 @@ def test_list_bp_not_empty(ocd):
         addr=0x10110FF0, size=2, bp_type=BpType.SW, orig_instr=0xABCD
     )
     ocd.cmd.assert_called_once_with("bp")
+
+
+def test_list_bp_invalid_response(ocd):
+    bp_command_output = (
+        "Hardware breakpoint(IVA): addr=0x10220000, len=0x2, num=0\n"
+        "Software breakpoint(IVA): muhehe"
+    )
+
+    ocd.cmd.return_value = _prepare_command_result(bp_command_output)
+    with pytest.raises(OcdInvalidResponseError) as e:
+        ocd.list_bp()
+
+    ocd.cmd.assert_called_once_with("bp")
+
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == bp_command_output
 
 
 def test_add_bp(ocd):
@@ -298,6 +335,22 @@ def test_list_wp_non_empty(ocd):
     )
 
 
+def test_list_wp_invalid_response(ocd):
+    wp_command_output = (
+        "address: 0x10002000, len: 0x00000004, r/w/a: r, value: 0x00000000, mask: 0xffffffffffffffff\n"  # noqa: E501
+        "address: 0x10002800, len: not_a_number, r/w/a: w, value: 0x00000000, mask: 0xffffffffffffffff\n"  # noqa: E501
+    )
+
+    ocd.cmd.return_value = _prepare_command_result(wp_command_output)
+    with pytest.raises(OcdInvalidResponseError) as e:
+        ocd.list_wp()
+
+    ocd.cmd.assert_called_once_with("wp")
+
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == wp_command_output
+
+
 def test_add_wp(ocd):
     ocd.add_wp(0x2001000, 2)
     ocd.cmd.assert_called_once_with("wp 0x2001000 2 a")
@@ -337,29 +390,31 @@ def test_version(ocd):
 
 
 def test_version_tuple(ocd):
-    ocd.version = mock.Mock()
-    ocd.version.return_value = "Open On-Chip Debugger 11.12.13 blah blah"
+    version_str = "Open On-Chip Debugger 11.12.13 blah blah"
+    ocd.cmd.return_value = _prepare_command_result(version_str)
     assert ocd.version_tuple() == (11, 12, 13)
 
 
 def test_version_tuple_2(ocd):
-    ocd.version = mock.Mock()
-    ocd.version.return_value = "My Little Open On-Chip Debugger 2.3.4 blah blah"
+    version_str = "My Little Open On-Chip Debugger 2.3.4 blah blah"
+    ocd.cmd.return_value = _prepare_command_result(version_str)
     assert ocd.version_tuple() == (2, 3, 4)
 
 
 def test_version_tuple_3(ocd):
-    ocd.version = mock.Mock()
-    ocd.version.return_value = "xPack Open On-Chip Debugger 0.12.0+dev-01557-gdd1758272-dirty (2024-04-02-07:27)"  # noqa: E501
+    version_str = "xPack Open On-Chip Debugger 0.12.0+dev-01557-gdd1758272-dirty (2024-04-02-07:27)"  # noqa: E501
+    ocd.cmd.return_value = _prepare_command_result(version_str)
     assert ocd.version_tuple() == (0, 12, 0)
 
 
 def test_version_tuple_error(ocd):
-    ocd.version = mock.Mock()
-    ocd.version.return_value = "Open On-Chip Debugger 9a.10b.11 blah blah"
-    with pytest.raises(ValueError) as e:
+    version_str = "Open On-Chip Debugger 9a.10b.11 blah blah"
+    ocd.cmd.return_value = _prepare_command_result(version_str)
+    with pytest.raises(OcdInvalidResponseError) as e:
         ocd.version_tuple()
     assert "Unable to parse the version string received from OpenOCD" in str(e)
+    assert e.value.full_cmd == "full_cmd_placeholder"
+    assert e.value.out == version_str
 
 
 def test_target_names(ocd):

--- a/tests_unit/py_openocd_client/test_errors.py
+++ b/tests_unit/py_openocd_client/test_errors.py
@@ -5,7 +5,7 @@ from py_openocd_client import OcdCommandFailedError, OcdCommandResult
 
 def test_ocd_command_error_to_string():
     cmd_result = OcdCommandResult(
-        retcode=8, cmd="my_cmd", full_cmd="my_full_cmd", out="abc\ndef\n"
+        retcode=8, cmd="my_cmd", raw_cmd="my_raw_cmd", out="abc\ndef\n"
     )
     cmd_error = OcdCommandFailedError(cmd_result)
 

--- a/tests_unit/py_openocd_client/test_errors.py
+++ b/tests_unit/py_openocd_client/test_errors.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 
-from py_openocd_client import OcdCommandError, OcdCommandResult
+from py_openocd_client import OcdCommandFailedError, OcdCommandResult
 
 
 def test_ocd_command_error_to_string():
     cmd_result = OcdCommandResult(
         retcode=8, cmd="my_cmd", full_cmd="my_full_cmd", out="abc\ndef\n"
     )
-    cmd_error = OcdCommandError(cmd_result)
+    cmd_error = OcdCommandFailedError(cmd_result)
 
     assert str(cmd_error) == "OpenOCD command failed: 'my_cmd' (error code: 8)"

--- a/tests_unit/py_openocd_client/test_wp_parser.py
+++ b/tests_unit/py_openocd_client/test_wp_parser.py
@@ -3,6 +3,7 @@
 import pytest
 
 from py_openocd_client import WpType
+from py_openocd_client.errors import _OcdParsingError
 from py_openocd_client.wp_parser import _WpParser
 
 
@@ -35,6 +36,6 @@ def test_parse_wp_entry_2():
 
 
 def test_parse_wp_entry_error():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(_OcdParsingError) as e:
         _WpParser.parse_wp_entry("malformed wp entry")
     assert "Could not parse" in str(e)


### PR DESCRIPTION
Rename exceptions to follow common naming conventions ("Error" suffix):

- `OcdError` --> `OcdBaseException`
- `OcdCommandError` --> `OcdCommandFailedError`
- `OcdCommandTimeout` --> `OcdCommandTimeoutError`
- `OcdCommandInvalidResponse` --> `OcdInvalidResponseError`

Add new attributes to some exceptions:

- OcdCommandTimeout now contains the `full_cmd` and `timeout`.
- OcdCommandInvalidReponse now contains the `full_cmd` and the command's textual output (`out`).

Use more descriptive exceptions:

- Commands that parse and interpret the OpenOCD's output now raise OcdCommandInvalidResponse (instead of ValueError) if they encounter a response they cannot understand