### PR TITLE
Reconnect on timeout

### DIFF
--- a/src/py_openocd_client/baseclient.py
+++ b/src/py_openocd_client/baseclient.py
@@ -177,11 +177,14 @@ class _PyOpenocdBaseClient:
         try:
             self._do_send_cmd(raw_cmd)
             return self._do_recv_response(raw_cmd, timeout=timeout)
-        except (OcdCommandTimeoutError, OcdConnectionError):
-            # Connection error -> disconnect.
-            # Timeout -> disconnect too. This is essential to avoid any
-            # late-arriving data to be interpreted as response to
+        except OcdCommandTimeoutError:
+            # Timeout -> reconnect. This is essential to avoid any
+            # late-arriving data to be interpreted as a response to
             # the next command.
+            self.reconnect()
+            raise
+        except OcdConnectionError:
+            # Connection error -> disconnect.
             self._close_socket()
             raise
 

--- a/tests_integration/py_openocd_client/test_integration_cmd.py
+++ b/tests_integration/py_openocd_client/test_integration_cmd.py
@@ -134,11 +134,10 @@ def test_timeout_exceeded(openocd_process):
         assert e.value.raw_cmd == expected_raw_cmd
         assert e.value.timeout == 1.0
 
-        # Timeout causes disconnection
-        assert not ocd.is_connected()
+        # Timeout causes re-connection, we must remain connected.
+        assert ocd.is_connected()
 
-        # After re-connection, commands must again work
-        ocd.reconnect()
+        # Commands must still work
         assert "Open On-Chip Debugger" in ocd.cmd("version").out
 
 

--- a/tests_unit/py_openocd_client/test_baseclient_errors.py
+++ b/tests_unit/py_openocd_client/test_baseclient_errors.py
@@ -273,7 +273,7 @@ def test_raw_cmd_reconnection_error_after_timeout(socket_inst_mock):
 
             # Command timeout must cause re-connection. The reconnection will fail,
             # resulting in OcdConnectionError.
-            with pytest.raises(OcdConnectionError) as e:
+            with pytest.raises(OcdConnectionError):
                 ocd_base.raw_cmd("my_command")
 
             # The first socket connection must have been closed.


### PR DESCRIPTION
Change the behavior on command timeout:

- Prior to this change: On command timeout, the connection was terminated and remained disconnected.
- New behavior: The connection is re-established automatically, no need for the user to reconnect manually.