### PR TITLE
Minor fix in doc (<target_name> curstate)

### DIFF
--- a/src/py_openocd_client/client.py
+++ b/src/py_openocd_client/client.py
@@ -298,8 +298,8 @@ class PyOpenocdClient:
 
     def curstate(self) -> str:
         """
-        Determinte the state of the currently selected target via the `currstate`
-        command. Return the state as a string.
+        Determinte the state of the currently selected target via
+        the ``<target_name> curstate`` command. Return the state as a string.
         """
         return self.cmd("[target current] curstate").out.strip()
 


### PR DESCRIPTION
There is no `currstate` command. The correct command syntax is `<target_name> curstate`.