### PR TITLE
Multiple fixes and improvements in the CI

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -1,5 +1,8 @@
 name: Build documentation
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '42 20 * * 2,4,6'
 jobs:
   build_doc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,5 +1,8 @@
 name: Code quality checks
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '42 20 * * 2,4,6'
 jobs:
   code_quality:
     runs-on: ubuntu-22.04

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,10 +1,14 @@
 name: Integration tests
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '42 20 * * 2,4,6'
 jobs:
   integration_tests_linux:
     name: OpenOCD on Linux
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         openocd_version:
           - vanilla-v0.10.0
@@ -15,6 +19,12 @@ jobs:
     steps:
       - name: Check out the repository code
         uses: actions/checkout@v4
+      # Make sure libjim (Jim Tcl) is available in the system. Newer versions of OpenOCD
+      # link with it (and no longer build jimtcl from source).
+      - name: Install libjim dependency (Jim Tcl)
+        run: |
+          sudo apt-get update
+          sudo apt-get install libjim-dev
       - name: Build OpenOCD ${{ matrix.openocd_version }}
         run: |
           mkdir -p oocd-build && cd oocd-build
@@ -37,7 +47,7 @@ jobs:
 
       - name: Download OpenOCD
         run: |
-          Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-3/xpack-openocd-0.12.0-3-win32-x64.zip" -OutFile "openocd.zip"
+          Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-win32-x64.zip" -OutFile "openocd.zip"
 
       - name: Unzip OpenOCD
         run: |
@@ -49,6 +59,6 @@ jobs:
 
       - name: Run integration testing
         run: |
-          python3 run_tests.py integration --force-pythonpath --openocd-path xpack-openocd-0.12.0-3\\bin\\openocd
+          python3 run_tests.py integration --force-pythonpath --openocd-path xpack-openocd-0.12.0-6\\bin\\openocd
 
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,8 @@
 name: Unit tests
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '42 20 * * 2,4,6'
 jobs:
   Run_unit_tests_ubuntu_22_04_py38_and_newer:
     runs-on: ubuntu-22.04
@@ -19,7 +22,6 @@ jobs:
             python3.11           \
             python3.11-distutils \
             python3.12           \
-            python3.12-distutils \
             python3.13
       - name: Install tox
         run: |

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -51,11 +51,16 @@ def test_catch_error(openocd_process):
         assert int(out) != 0  # error code
 
 
+def test_catch_throw(openocd_process):
+    with PyOpenocdClient() as ocd:
+        out = ocd.raw_cmd('return [ catch { throw 22 "Error message" } ]')
+        assert int(out) == 22  # error code
+
+
 def test_catch_output_and_success(openocd_process):
     with PyOpenocdClient() as ocd:
-        out = ocd.raw_cmd(
-            'set RETCODE [ catch { version } OUT ]; return "$RETCODE $OUT" '
-        )
+        cmd = 'set RETCODE [ catch { version } OUT ]; return "$RETCODE $OUT" '
+        out = ocd.raw_cmd(cmd)
 
         parts = out.split(" ", maxsplit=1)
         retcode = int(parts[0])
@@ -67,9 +72,8 @@ def test_catch_output_and_success(openocd_process):
 
 def test_catch_output_and_error(openocd_process):
     with PyOpenocdClient() as ocd:
-        out = ocd.raw_cmd(
-            'set RETCODE [ catch { nonexistent_cmd } OUT; ]; return "$RETCODE $OUT" '
-        )
+        cmd = 'set RETCODE [ catch { nonexistent_cmd } OUT; ]; return "$RETCODE $OUT" '
+        out = ocd.raw_cmd(cmd)
 
         parts = out.split(" ", maxsplit=1)
         retcode = int(parts[0])
@@ -77,6 +81,19 @@ def test_catch_output_and_error(openocd_process):
 
         assert retcode != 0  # error code
         assert "invalid command" in out
+
+
+def test_catch_output_and_throw(openocd_process):
+    with PyOpenocdClient() as ocd:
+        cmd = 'set RETCODE [catch { throw 25 {my msg} } OUT;]; return "$RETCODE $OUT"'
+        out = ocd.raw_cmd(cmd)
+
+        parts = out.split(" ", maxsplit=1)
+        retcode = int(parts[0])
+        out = parts[1]
+
+        assert retcode == 25  # error code
+        assert out == "my msg"
 
 
 def test_raw_cmd_timeout_ok(openocd_process):


### PR DESCRIPTION
Unit tests:

- Don't attempt to install "python3.12-distutils". This package
  does not exist.

Integration tests:

- Make sure libjim is installed. This is needed when building newer
  versions of OpenOCD.

- Replace `return -code <code>` by `throw <code>` in the tests.
  The former seems to not work correctly in older Jim Tcl.

- Expand the tests by adding few variants with "throw".

- Bump the xpack OpenOCD version that is used for integration
  testing on Windows: 0.12.0-3 --> 0.12.0-6

- Continue with integration tests even if one variant fails
  (fail-fast: false).

Schedule:

- Set all CI jobs to run automatically 3 times a week