### PR TITLE
Use more Jim Tcl versions for testing

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,20 +11,18 @@ jobs:
       fail-fast: false
       matrix:
         openocd_version:
+          # Released versions of OpenOCD:
           - vanilla-v0.10.0
           - vanilla-v0.11.0
           - vanilla-v0.12.0
-          - vanilla-master
-          - riscv-master
+          # Development versions of OpenOCD (with different Jim Tcl interpreter versions):
+          - vanilla-master-default-libjim
+          - vanilla-master-libjim-0.83
+          - riscv-master-default-libjim
+          - riscv-master-libjim-0.83
     steps:
       - name: Check out the repository code
         uses: actions/checkout@v4
-      # Make sure libjim (Jim Tcl) is available in the system. Newer versions of OpenOCD
-      # link with it (and no longer build jimtcl from source).
-      - name: Install libjim dependency (Jim Tcl)
-        run: |
-          sudo apt-get update
-          sudo apt-get install libjim-dev
       - name: Build OpenOCD ${{ matrix.openocd_version }}
         run: |
           mkdir -p oocd-build && cd oocd-build
@@ -36,7 +34,7 @@ jobs:
 
       - name: Run integration test
         run: |
-          python3 run_tests.py integration --force-pythonpath --openocd-path oocd-build/install/${{ matrix.openocd_version }}/bin/openocd
+          python3 run_tests.py integration --force-pythonpath --openocd-path oocd-build/install/${{ matrix.openocd_version }}/openocd/bin/openocd
 
   integration_test_windows:
     name: OpenOCD on Windows

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Check out the repository code
         uses: actions/checkout@v4
+
       - name: Build OpenOCD ${{ matrix.openocd_version }}
         run: |
           mkdir -p oocd-build && cd oocd-build

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,15 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         openocd_version:
-          # Released versions of OpenOCD:
-          - vanilla-v0.10.0
-          - vanilla-v0.11.0
-          - vanilla-v0.12.0
-          # Development versions of OpenOCD (with different Jim Tcl interpreter versions):
-          - vanilla-master-default-libjim
+          - vanilla-0.10.0
+          - vanilla-0.11.0
+          - vanilla-0.12.0
+          - vanilla-master-libjim-from-apt
+          - vanilla-master-libjim-internal
+          - vanilla-master-libjim-0.79
           - vanilla-master-libjim-0.83
-          - riscv-master-default-libjim
-          - riscv-master-libjim-0.83
+          - riscv-master-libjim-from-apt
     steps:
       - name: Check out the repository code
         uses: actions/checkout@v4
@@ -34,7 +33,9 @@ jobs:
 
       - name: Run integration test
         run: |
-          python3 run_tests.py integration --force-pythonpath --openocd-path oocd-build/install/${{ matrix.openocd_version }}/openocd/bin/openocd
+          python3 run_tests.py integration \
+              --force-pythonpath \
+              --openocd-path oocd-build/install/${{ matrix.openocd_version }}/openocd/bin/openocd
 
   integration_test_windows:
     name: OpenOCD on Windows

--- a/run_code_quality_check.py
+++ b/run_code_quality_check.py
@@ -83,6 +83,7 @@ def main() -> int:
         get_script_dir() / "run_code_quality_check.py",
         get_script_dir() / "run_tests.py",
         get_script_dir() / "make_release.py",
+        get_script_dir() / "tests_integration" / "build_openocd.py",
     ]
 
     run_tool_isort(args.edit, srcs + tests + utils)

--- a/tests_integration/build_openocd.py
+++ b/tests_integration/build_openocd.py
@@ -8,34 +8,57 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_VANILLA = "https://github.com/openocd-org/openocd.git"
-REPO_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
+REPO_OPENOCD_VANILLA = "https://github.com/openocd-org/openocd.git"
+REPO_OPENOCD_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
+
+REPO_LIBJIM = "https://github.com/msteveb/jimtcl.git"
+LIBJIM_CONFIGURE_ARGS = ["--with-ext=json", "--minimal", "--disable-ssl"]
+
+LIBJIM_FROM_APT = "apt"
+LIBJIM_FROM_SOURCE_0_83 = "0.83"
 
 BUILD_INFO = {
     "vanilla-v0.10.0": {
-        "repo": REPO_VANILLA,
+        "repo": REPO_OPENOCD_VANILLA,
         "git_rev": "v0.10.0",
         "extra_cflags": "-Wno-error",
+        "libjim_version": None,
     },
     "vanilla-v0.11.0": {
-        "repo": REPO_VANILLA,
+        "repo": REPO_OPENOCD_VANILLA,
         "git_rev": "v0.11.0",
         "extra_cflags": "-Wno-error",
+        "libjim_version": None,
     },
     "vanilla-v0.12.0": {
-        "repo": REPO_VANILLA,
+        "repo": REPO_OPENOCD_VANILLA,
         "git_rev": "v0.12.0",
         "extra_cflags": "",
+        "libjim_version": None,
     },
-    "vanilla-master": {
-        "repo": REPO_VANILLA,
+    "vanilla-master-default-libjim": {
+        "repo": REPO_OPENOCD_VANILLA,
         "git_rev": "master",
         "extra_cflags": "",
+        "libjim_version": LIBJIM_FROM_APT,
     },
-    "riscv-master": {
-        "repo": REPO_RISCV,
+    "vanilla-master-libjim-0.83": {
+        "repo": REPO_OPENOCD_VANILLA,
+        "git_rev": "master",
+        "extra_cflags": "",
+        "libjim_version": LIBJIM_FROM_SOURCE_0_83,
+    },
+    "riscv-master-default-libjim": {
+        "repo": REPO_OPENOCD_RISCV,
         "git_rev": "riscv",
         "extra_cflags": "",
+        "libjim_version": LIBJIM_FROM_APT,
+    },
+    "riscv-master-libjim-0.83": {
+        "repo": REPO_OPENOCD_RISCV,
+        "git_rev": "riscv",
+        "extra_cflags": "",
+        "libjim_version": LIBJIM_FROM_SOURCE_0_83,
     },
 }
 
@@ -49,14 +72,14 @@ def get_script_dir() -> Path:
     return Path(__file__).resolve().parent
 
 
-def get_src_dir(version: str) -> Path:
-    """Return path to the directory with sources of given OpenOCD version."""
-    return initial_work_dir / "src" / version
+def get_src_dir(version: str, program: str) -> Path:
+    """Return path to the directory with sources of OpenOCD or Jim Tcl."""
+    return initial_work_dir / "src" / version / program
 
 
-def get_install_dir(version: str) -> Path:
-    """Return path to the directory where given version of OpenOCD will be installed."""
-    return initial_work_dir / "install" / version
+def get_install_dir(version: str, program: str) -> Path:
+    """Return path to the directory with installed OpenOCD or Jim Tcl."""
+    return initial_work_dir / "install" / version / program
 
 
 def parse_args() -> argparse.Namespace:
@@ -78,10 +101,45 @@ def run_cmd(cmd: list[str], cwd: str | None = None, env=None) -> None:
     subprocess.check_call(cmd, cwd=cwd, env=env)
 
 
-def perform_build(version: str) -> None:
-    src_dir = get_src_dir(version)
+def prepare_libjim(version: str) -> None:
+    libjim_version = BUILD_INFO[version]["libjim_version"]
+
+    if libjim_version is None:
+        return
+    elif libjim_version == LIBJIM_FROM_APT:
+        run_cmd(["sudo", "apt-get", "install", "-y", "libjim-dev"])
+    else:
+        checkout_and_build_libjim(version)
+
+
+def checkout_and_build_libjim(version: str) -> None:
+    src_dir = get_src_dir(version, "libjim")
+    install_dir = get_install_dir(version, "libjim")
     recreate_dir(src_dir)
-    install_dir = get_install_dir(version)
+    recreate_dir(install_dir)
+
+    run_cmd(["git", "clone", REPO_LIBJIM, "."], cwd=src_dir)
+    run_cmd(["git", "checkout", BUILD_INFO[version]["libjim_version"]], cwd=src_dir)
+    run_cmd(
+        ["git", "--no-pager", "show", "--no-patch"], cwd=src_dir
+    )  # show current commit
+
+    configure_cmd = [
+        "/bin/sh",
+        "./configure",
+        "--prefix=" + str(install_dir),
+    ] + LIBJIM_CONFIGURE_ARGS
+    run_cmd(configure_cmd, cwd=src_dir)
+
+    nproc = min(multiprocessing.cpu_count(), 8)  # safety
+    run_cmd(["make", f"-j{nproc}"], cwd=src_dir)
+    run_cmd(["make", "install"], cwd=src_dir)
+
+
+def checkout_and_build_openocd(version: str) -> None:
+    src_dir = get_src_dir(version, "openocd")
+    install_dir = get_install_dir(version, "openocd")
+    recreate_dir(src_dir)
     recreate_dir(install_dir)
 
     run_cmd(["git", "clone", BUILD_INFO[version]["repo"], "."], cwd=src_dir)
@@ -93,8 +151,19 @@ def perform_build(version: str) -> None:
     run_cmd(["/bin/sh", "./bootstrap"], cwd=src_dir)
 
     extra_cflags = BUILD_INFO[version]["extra_cflags"]
+
     env = os.environ.copy()
     env["CFLAGS"] = extra_cflags
+
+    libjim_is_from_source = BUILD_INFO[version]["libjim_version"] not in [
+        None,
+        LIBJIM_FROM_APT,
+    ]
+    if libjim_is_from_source:
+        env["PKG_CONFIG_PATH"] = (
+            get_install_dir(version, "libjim") / "lib" / "pkgconfig"
+        )
+
     run_cmd(
         ["/bin/sh", "./configure", "--prefix=" + str(install_dir)], cwd=src_dir, env=env
     )
@@ -105,7 +174,7 @@ def perform_build(version: str) -> None:
 
 
 def check_build(version: str) -> None:
-    install_dir = get_install_dir(version)
+    install_dir = get_install_dir(version, "openocd")
 
     openocd_bin = install_dir / "bin" / "openocd"
     if not openocd_bin.is_file():
@@ -119,8 +188,11 @@ def check_build(version: str) -> None:
 
 def main() -> int:
     args = parse_args()
-    perform_build(args.version)
+
+    prepare_libjim(args.version)
+    checkout_and_build_openocd(args.version)
     check_build(args.version)
+
     return 0
 
 

--- a/tests_integration/build_openocd.py
+++ b/tests_integration/build_openocd.py
@@ -21,12 +21,14 @@ NPROC = min(multiprocessing.cpu_count(), 8)
 
 @dataclass
 class LibJimVersion:
+    is_internal: bool = False
+    is_from_apt: bool = False
     git_rev: str | None = None
     extra_configure_args: list[str] = field(default_factory=lambda: [])
 
 
-LIBJIM_FROM_APT = LibJimVersion()
-LIBJIM_INTERNAL = LibJimVersion()
+LIBJIM_FROM_APT = LibJimVersion(is_from_apt=True)
+LIBJIM_INTERNAL = LibJimVersion(is_internal=True)
 LIBJIM_FROM_SOURCE_0_79 = LibJimVersion(
     # JimTcl version used in Debian 11
     git_rev="0.79",

--- a/tests_integration/build_openocd.py
+++ b/tests_integration/build_openocd.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
 import argparse
+from dataclasses import dataclass
+from enum import Enum
 import multiprocessing
 import os
 import shutil
@@ -12,57 +14,102 @@ REPO_OPENOCD_VANILLA = "https://github.com/openocd-org/openocd.git"
 REPO_OPENOCD_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
 
 REPO_LIBJIM = "https://github.com/msteveb/jimtcl.git"
-LIBJIM_CONFIGURE_ARGS = ["--with-ext=json", "--minimal", "--disable-ssl"]
+LIBJIM_CONFIGURE_ARGS = ["--with-ext=json", "--disable-ssl"]
 
-LIBJIM_FROM_APT = "apt"
-LIBJIM_FROM_SOURCE_0_83 = "0.83"
+# Build parallelism. (The upper limit is for safety.)
+NPROC = min(multiprocessing.cpu_count(), 8)
 
-BUILD_INFO = {
-    "vanilla-v0.10.0": {
-        "repo": REPO_OPENOCD_VANILLA,
-        "git_rev": "v0.10.0",
-        "extra_cflags": "-Wno-error",
-        "libjim_version": None,
-    },
-    "vanilla-v0.11.0": {
-        "repo": REPO_OPENOCD_VANILLA,
-        "git_rev": "v0.11.0",
-        "extra_cflags": "-Wno-error",
-        "libjim_version": None,
-    },
-    "vanilla-v0.12.0": {
-        "repo": REPO_OPENOCD_VANILLA,
-        "git_rev": "v0.12.0",
-        "extra_cflags": "",
-        "libjim_version": None,
-    },
-    "vanilla-master-default-libjim": {
-        "repo": REPO_OPENOCD_VANILLA,
-        "git_rev": "master",
-        "extra_cflags": "",
-        "libjim_version": LIBJIM_FROM_APT,
-    },
-    "vanilla-master-libjim-0.83": {
-        "repo": REPO_OPENOCD_VANILLA,
-        "git_rev": "master",
-        "extra_cflags": "",
-        "libjim_version": LIBJIM_FROM_SOURCE_0_83,
-    },
-    "riscv-master-default-libjim": {
-        "repo": REPO_OPENOCD_RISCV,
-        "git_rev": "riscv",
-        "extra_cflags": "",
-        "libjim_version": LIBJIM_FROM_APT,
-    },
-    "riscv-master-libjim-0.83": {
-        "repo": REPO_OPENOCD_RISCV,
-        "git_rev": "riscv",
-        "extra_cflags": "",
-        "libjim_version": LIBJIM_FROM_SOURCE_0_83,
-    },
-}
 
-KNOWN_VERSIONS = list(BUILD_INFO.keys())
+class LibJimVersion(Enum):
+    FROM_APT = "apt"
+    INTERNAL = "internal"  # From submodule in OpenOCD repo
+    FROM_SOURCE_0_79 = "0.79"  # Used in Debian 11
+    FROM_SOURCE_0_83 = "0.83"
+
+
+@dataclass
+class OpenOcdVersion:
+    name: str
+    repo: str
+    git_rev: str
+    extra_cflags: str
+    extra_configure_args: list[str]
+    libjim: LibJimVersion
+
+
+# Various combinations of:
+# - OpenOCD version
+# - JimTcl version
+OPENOCD_VERSIONS = [
+    OpenOcdVersion(
+        name="vanilla-0.10.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.10.0",
+        # Older OpenOCD code has compilation warnings on new GCC
+        extra_cflags="-Wno-error",
+        extra_configure_args=[],
+        libjim=LibJimVersion.INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-0.11.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.11.0",
+        # Older OpenOCD code has compilation warnings on new GCC
+        extra_cflags="-Wno-error",
+        extra_configure_args=[],
+        libjim=LibJimVersion.INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-0.12.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.12.0",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LibJimVersion.INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-from-apt",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LibJimVersion.FROM_APT,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-internal",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=["--enable-internal-jimtcl"],
+        libjim=LibJimVersion.INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-0.79",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LibJimVersion.FROM_SOURCE_0_79,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-0.83",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LibJimVersion.FROM_SOURCE_0_83,
+    ),
+    OpenOcdVersion(
+        name="riscv-master-libjim-from-apt",
+        repo=REPO_OPENOCD_RISCV,
+        git_rev="riscv",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LibJimVersion.FROM_APT,
+    ),
+]
+
+OPENOCD_VERSION_NAMES = [v.name for v in OPENOCD_VERSIONS]
 
 initial_work_dir = Path(os.getcwd()).resolve()
 
@@ -82,12 +129,19 @@ def get_install_dir(version: str, program: str) -> Path:
     return initial_work_dir / "install" / version / program
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "version", choices=KNOWN_VERSIONS, help="OpenOCD version to build"
+def parse_args() -> OpenOcdVersion:
+    desc = (
+        "Script that downloads OpenOCD source code and performs the from-source build. "
+        "JimTcl is also built from source if needed."
     )
-    return parser.parse_args()
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        "version_name", choices=OPENOCD_VERSION_NAMES, help="OpenOCD version to build"
+    )
+    args = parser.parse_args()
+
+    assert args.version_name in OPENOCD_VERSION_NAMES
+    return next(v for v in OPENOCD_VERSIONS if v.name == args.version_name)
 
 
 def recreate_dir(d: Path):
@@ -101,28 +155,36 @@ def run_cmd(cmd: list[str], cwd: str | None = None, env=None) -> None:
     subprocess.check_call(cmd, cwd=cwd, env=env)
 
 
-def prepare_libjim(version: str) -> None:
-    libjim_version = BUILD_INFO[version]["libjim_version"]
+def git_show_current_commit(cwd: Path) -> None:
+    assert cwd.is_dir()
+    run_cmd(
+        ["git", "--no-pager", "show", "--no-patch"], cwd=cwd
+    )
 
-    if libjim_version is None:
-        return
-    elif libjim_version == LIBJIM_FROM_APT:
+
+def prepare_libjim(libjim_version: LibJimVersion) -> None:
+    if libjim_version == LibJimVersion.INTERNAL:
+        # Do not install anything
+        pass
+    elif libjim_version == LibJimVersion.FROM_APT:
         run_cmd(["sudo", "apt-get", "install", "-y", "libjim-dev"])
     else:
-        checkout_and_build_libjim(version)
+        checkout_and_build_libjim(libjim_version)
 
 
-def checkout_and_build_libjim(version: str) -> None:
-    src_dir = get_src_dir(version, "libjim")
-    install_dir = get_install_dir(version, "libjim")
+def checkout_and_build_libjim(libjim_version: LibJimVersion) -> None:
+    assert libjim_version not in [LibJimVersion.INTERNAL, LibJimVersion.FROM_APT]
+
+    libjim_rev = libjim_version.value
+
+    src_dir = get_src_dir(libjim_rev, "libjim")
+    install_dir = get_install_dir(libjim_rev, "libjim")
     recreate_dir(src_dir)
     recreate_dir(install_dir)
 
     run_cmd(["git", "clone", REPO_LIBJIM, "."], cwd=src_dir)
-    run_cmd(["git", "checkout", BUILD_INFO[version]["libjim_version"]], cwd=src_dir)
-    run_cmd(
-        ["git", "--no-pager", "show", "--no-patch"], cwd=src_dir
-    )  # show current commit
+    run_cmd(["git", "checkout", libjim_rev], cwd=src_dir)
+    git_show_current_commit(cwd=src_dir)
 
     configure_cmd = [
         "/bin/sh",
@@ -131,67 +193,62 @@ def checkout_and_build_libjim(version: str) -> None:
     ] + LIBJIM_CONFIGURE_ARGS
     run_cmd(configure_cmd, cwd=src_dir)
 
-    nproc = min(multiprocessing.cpu_count(), 8)  # safety
-    run_cmd(["make", f"-j{nproc}"], cwd=src_dir)
+    run_cmd(["make", f"-j{NPROC}"], cwd=src_dir)
     run_cmd(["make", "install"], cwd=src_dir)
 
+    # Make sure ./configure finds the built libjim library
+    os.environ["PKG_CONFIG_PATH"] = str(install_dir / "lib" / "pkgconfig")
 
-def checkout_and_build_openocd(version: str) -> None:
-    src_dir = get_src_dir(version, "openocd")
-    install_dir = get_install_dir(version, "openocd")
+
+def checkout_and_build_openocd(version: OpenOcdVersion) -> None:
+    src_dir = get_src_dir(version.name, "openocd")
+    install_dir = get_install_dir(version.name, "openocd")
     recreate_dir(src_dir)
     recreate_dir(install_dir)
 
-    run_cmd(["git", "clone", BUILD_INFO[version]["repo"], "."], cwd=src_dir)
-    run_cmd(["git", "checkout", BUILD_INFO[version]["git_rev"]], cwd=src_dir)
-    run_cmd(
-        ["git", "--no-pager", "show", "--no-patch"], cwd=src_dir
-    )  # show current commit
-    run_cmd(["git", "submodule", "update", "--init", "--recursive"], cwd=src_dir)
+    run_cmd(["git", "clone", version.repo, "."], cwd=src_dir)
+    run_cmd(["git", "checkout", version.git_rev], cwd=src_dir)
+    git_show_current_commit(cwd=src_dir)
+
+    if version.libjim == LibJimVersion.INTERNAL:
+        # Need to checkout the jimtcl submodule
+        run_cmd(["git", "submodule", "update", "--init", "--recursive"], cwd=src_dir)
+
     run_cmd(["/bin/sh", "./bootstrap"], cwd=src_dir)
 
-    extra_cflags = BUILD_INFO[version]["extra_cflags"]
+    configure_env = os.environ.copy()
+    configure_env["CFLAGS"] = version.extra_cflags
 
-    env = os.environ.copy()
-    env["CFLAGS"] = extra_cflags
+    configure_cmd = ["/bin/sh", "./configure", "--prefix=" + str(install_dir)]
+    configure_cmd += version.extra_configure_args
 
-    libjim_is_from_source = BUILD_INFO[version]["libjim_version"] not in [
-        None,
-        LIBJIM_FROM_APT,
-    ]
-    if libjim_is_from_source:
-        env["PKG_CONFIG_PATH"] = (
-            get_install_dir(version, "libjim") / "lib" / "pkgconfig"
-        )
-
-    run_cmd(
-        ["/bin/sh", "./configure", "--prefix=" + str(install_dir)], cwd=src_dir, env=env
-    )
-
-    nproc = min(multiprocessing.cpu_count(), 8)  # safety
-    run_cmd(["make", f"-j{nproc}"], cwd=src_dir)
+    run_cmd(configure_cmd, cwd=src_dir, env=configure_env)
+    run_cmd(["make", f"-j{NPROC}"], cwd=src_dir)
     run_cmd(["make", "install"], cwd=src_dir)
 
 
-def check_build(version: str) -> None:
-    install_dir = get_install_dir(version, "openocd")
+def check_build(version: OpenOcdVersion) -> None:
+    install_dir = get_install_dir(version.name, "openocd")
 
     openocd_bin = install_dir / "bin" / "openocd"
     if not openocd_bin.is_file():
         raise RuntimeError(
-            f"Expected binary does not exist after the build: {str(openocd_bin)}"
+            f"The expected binary does not exist after the build: {str(openocd_bin)}"
         )
 
     run_cmd([openocd_bin, "--version"])
-    print(f'OpenOCD "{version}" successfully built: {str(openocd_bin)}')
+
+    print()
+    print(f'OpenOCD "{version.name}" successfully built!')
+    print(f"Path to the OpenOCD binary: {str(openocd_bin)}")
 
 
 def main() -> int:
-    args = parse_args()
+    openocd_version = parse_args()
 
-    prepare_libjim(args.version)
-    checkout_and_build_openocd(args.version)
-    check_build(args.version)
+    prepare_libjim(openocd_version.libjim)
+    checkout_and_build_openocd(openocd_version)
+    check_build(openocd_version)
 
     return 0
 


### PR DESCRIPTION
The Tcl interface of OpenOCD depends not only on the OpenOCD version itself but also on the version of the built-in Jim Tcl interpreter.

For that reason, run the integration tests on multiple Jim Tcl versions, too.