### PR TITLE
Fix PyOpenocdClient.shutdown() call

### DIFF
--- a/src/py_openocd_client/client.py
+++ b/src/py_openocd_client/client.py
@@ -682,7 +682,7 @@ class PyOpenocdClient:
         # For the above reasons, send the shutdown command via raw_cmd() and:
         # - don't wrap "shutdown" into any other TCL commands,
         # - don't expect any particular response.
-        self.raw_cmd("shutdown", throw=False)
+        self.raw_cmd("shutdown")
 
         self.disconnect()
 

--- a/tests_unit/test_client_commands.py
+++ b/tests_unit/test_client_commands.py
@@ -451,6 +451,8 @@ def test_exit(ocd):
 
 def test_shutdown(ocd):
     ocd.disconnect = mock.Mock()
+    ocd.raw_cmd = mock.Mock()
     ocd.shutdown()
-    ocd.cmd.assert_called_once_with("shutdown", throw=False)
+    assert not ocd.cmd.called
+    ocd.raw_cmd.assert_called_once_with("shutdown")
     ocd.disconnect.assert_called_once()


### PR DESCRIPTION
In commit [1], OpenOCD started to respond differently to "shutdown" command on the TCL connection.

Update the shutdown() method of PyOpenocdClient so that it continues to work with both the old and new OpenOCD responses.

[1] OpenOCD commit 93f16eed4, https://review.openocd.org/c/openocd/+/9084