### PR TITLE
Fix integration tests related to whitespace

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build OpenOCD ${{ matrix.openocd_version }}
         run: |
           mkdir -p oocd-build && cd oocd-build
-          python3 ../tests_integration/build_openocd.py ${{ matrix.openocd_version }}
+          python3 ../tests_integration/build_openocd.py --openocd-version ${{ matrix.openocd_version }}
 
       - name: Install pytest
         run: |
@@ -36,7 +36,8 @@ jobs:
         run: |
           python3 run_tests.py integration \
               --force-pythonpath \
-              --openocd-path oocd-build/install/${{ matrix.openocd_version }}/openocd/bin/openocd
+              --openocd-path oocd-build/install/${{ matrix.openocd_version }}/openocd/bin/openocd \
+              --openocd-version ${{ matrix.openocd_version }}
 
   integration_test_windows:
     name: OpenOCD on Windows
@@ -59,6 +60,6 @@ jobs:
 
       - name: Run integration testing
         run: |
-          python3 run_tests.py integration --force-pythonpath --openocd-path xpack-openocd-0.12.0-6\\bin\\openocd
+          python3 run_tests.py integration --force-pythonpath --openocd-path xpack-openocd-0.12.0-6\\bin\\openocd --openocd-version vanilla-0.12.0
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -57,7 +57,9 @@ def run_unittests(enable_coverage: bool) -> None:
     run_subproc(cmd)
 
 
-def run_integration_tests(openocd_path: Path, openocd_version: str, enable_coverage: bool) -> None:
+def run_integration_tests(
+    openocd_path: Path, openocd_version: str, enable_coverage: bool
+) -> None:
     pytest_args = [
         "-m",
         "pytest",

--- a/run_tests.py
+++ b/run_tests.py
@@ -35,6 +35,9 @@ def parse_args() -> argparse.Namespace:
         "--openocd-path", help="Path to OpenOCD executable", default=None
     )
     parser.add_argument(
+        "--openocd-version", help="OpenOCD version being tested", default=None
+    )
+    parser.add_argument(
         "test_type", choices=["unit", "integration"], help="Type of the tests"
     )
     return parser.parse_args()
@@ -54,7 +57,7 @@ def run_unittests(enable_coverage: bool) -> None:
     run_subproc(cmd)
 
 
-def run_integration_tests(openocd_path: Path, enable_coverage: bool) -> None:
+def run_integration_tests(openocd_path: Path, openocd_version: str, enable_coverage: bool) -> None:
     pytest_args = [
         "-m",
         "pytest",
@@ -62,6 +65,8 @@ def run_integration_tests(openocd_path: Path, enable_coverage: bool) -> None:
         "-vv",
         "--openocd-path",
         str(openocd_path),
+        "--openocd-version",
+        str(openocd_version),
     ]
     if enable_coverage:
         cmd = [sys.executable, "-m", "coverage", "run"] + pytest_args
@@ -100,13 +105,17 @@ def main() -> int:
     if args.test_type == "unit":
         if args.openocd_path:
             raise RuntimeError("--openocd-path is irrelevant for unittests")
+        if args.openocd_version:
+            raise RuntimeError("--openocd-version is irrelevant for unittests")
         run_unittests(args.coverage)
 
     elif args.test_type == "integration":
         if not args.openocd_path:
             raise RuntimeError("--openocd-path is required for integration tests")
+        if not args.openocd_version:
+            raise RuntimeError("--openocd-version is required for integration tests")
         openocd_path = Path(args.openocd_path).resolve()
-        run_integration_tests(openocd_path, args.coverage)
+        run_integration_tests(openocd_path, args.openocd_version, args.coverage)
 
     else:
         assert False

--- a/tests_integration/build_openocd.py
+++ b/tests_integration/build_openocd.py
@@ -9,7 +9,14 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from openocd_version_info import OPENOCD_VERSIONS, OPENOCD_VERSION_NAMES, OpenOcdVersion, LIBJIM_FROM_APT, LIBJIM_INTERNAL
+
+from openocd_version_info import (
+    LIBJIM_FROM_APT,
+    LIBJIM_INTERNAL,
+    OPENOCD_VERSION_NAMES,
+    OPENOCD_VERSIONS,
+    OpenOcdVersion,
+)
 
 # Build parallelism. (The upper limit is for safety.)
 NPROC = min(multiprocessing.cpu_count(), 8)
@@ -42,7 +49,7 @@ def parse_args() -> OpenOcdVersion:
         "--openocd-version",
         choices=OPENOCD_VERSION_NAMES,
         required=True,
-        help="OpenOCD version to build"
+        help="OpenOCD version to build",
     )
     args = parser.parse_args()
 

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -3,14 +3,19 @@
 import subprocess
 import time
 from pathlib import Path
-from openocd_version_info import OPENOCD_VERSION_NAMES
 
 import pytest
+from openocd_version_info import OPENOCD_VERSION_NAMES
 
 
 def pytest_addoption(parser):
     parser.addoption("--openocd-path", action="store", required=True)
-    parser.addoption("--openocd-version", action="store", required=True, choices=OPENOCD_VERSION_NAMES)
+    parser.addoption(
+        "--openocd-version",
+        action="store",
+        required=True,
+        choices=OPENOCD_VERSION_NAMES,
+    )
 
 
 @pytest.fixture

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -3,17 +3,38 @@
 import subprocess
 import time
 from pathlib import Path
+from openocd_version_info import OPENOCD_VERSION_NAMES
 
 import pytest
 
 
 def pytest_addoption(parser):
     parser.addoption("--openocd-path", action="store", required=True)
+    parser.addoption("--openocd-version", action="store", required=True, choices=OPENOCD_VERSION_NAMES)
 
 
 @pytest.fixture
 def openocd_path(pytestconfig):
     return Path(pytestconfig.getoption("openocd_path")).resolve()
+
+
+@pytest.fixture
+def openocd_version(pytestconfig):
+    version = pytestconfig.getoption("openocd_version")
+    assert version in OPENOCD_VERSION_NAMES
+    return version
+
+
+@pytest.fixture
+def has_buggy_whitespace_trim(openocd_version):
+    """
+    Detect if the OpenOCD version being tested has a known buggy whitespace handling.
+
+    In OpenOCD prior to version 0.13.0, the "return" command performed extra
+    whitespace trimming on the command output. This was fixed in commit "93f16eed4,
+    https://review.openocd.org/c/openocd/+/9084.
+    """
+    return openocd_version in ["vanilla-0.10.0", "vanilla-0.11.0", "vanilla-0.12.0"]
 
 
 @pytest.fixture

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -34,7 +34,12 @@ def has_buggy_whitespace_trim(openocd_version):
     whitespace trimming on the command output. This was fixed in commit "93f16eed4,
     https://review.openocd.org/c/openocd/+/9084.
     """
-    return openocd_version in ["vanilla-0.10.0", "vanilla-0.11.0", "vanilla-0.12.0"]
+    return openocd_version in [
+        "vanilla-0.10.0",
+        "vanilla-0.11.0",
+        "vanilla-0.12.0",
+        "riscv-master-libjim-from-apt",
+    ]
 
 
 @pytest.fixture

--- a/tests_integration/openocd_version_info.py
+++ b/tests_integration/openocd_version_info.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass, field
+
+REPO_OPENOCD_VANILLA = "https://github.com/openocd-org/openocd.git"
+REPO_OPENOCD_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
+
+REPO_LIBJIM = "https://github.com/msteveb/jimtcl.git"
+
+
+@dataclass
+class LibJimVersion:
+    is_internal: bool = False
+    is_from_apt: bool = False
+    repo: str | None = None
+    git_rev: str | None = None
+    extra_configure_args: list[str] = field(default_factory=lambda: [])
+
+
+LIBJIM_FROM_APT = LibJimVersion(is_from_apt=True)
+LIBJIM_INTERNAL = LibJimVersion(is_internal=True)
+LIBJIM_FROM_SOURCE_0_79 = LibJimVersion(
+    # JimTcl version used in Debian 11
+    repo=REPO_LIBJIM,
+    git_rev="0.79",
+    extra_configure_args=["--with-ext=json", "--disable-ssl"],
+)
+LIBJIM_FROM_SOURCE_0_83 = LibJimVersion(
+    # Latest JimTcl release as of March 2025
+    repo=REPO_LIBJIM,
+    git_rev="0.83",
+    extra_configure_args=["--with-ext=json", "--disable-ssl", "--minimal"],
+)
+
+
+@dataclass
+class OpenOcdVersion:
+    name: str
+    repo: str
+    git_rev: str
+    extra_cflags: str
+    extra_configure_args: list[str]
+    libjim: LibJimVersion
+
+
+# Various combinations of OpenOCD and JimTcl versions that we test against:
+OPENOCD_VERSIONS = [
+    OpenOcdVersion(
+        name="vanilla-0.10.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.10.0",
+        # Older OpenOCD code has compilation warnings on new GCC
+        extra_cflags="-Wno-error",
+        extra_configure_args=[],
+        libjim=LIBJIM_INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-0.11.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.11.0",
+        # Older OpenOCD code has compilation warnings on new GCC
+        extra_cflags="-Wno-error",
+        extra_configure_args=[],
+        libjim=LIBJIM_INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-0.12.0",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="v0.12.0",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LIBJIM_INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-from-apt",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LIBJIM_FROM_APT,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-internal",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=["--enable-internal-jimtcl"],
+        libjim=LIBJIM_INTERNAL,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-0.79",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LIBJIM_FROM_SOURCE_0_79,
+    ),
+    OpenOcdVersion(
+        name="vanilla-master-libjim-0.83",
+        repo=REPO_OPENOCD_VANILLA,
+        git_rev="master",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LIBJIM_FROM_SOURCE_0_83,
+    ),
+    OpenOcdVersion(
+        name="riscv-master-libjim-from-apt",
+        repo=REPO_OPENOCD_RISCV,
+        git_rev="riscv",
+        extra_cflags="",
+        extra_configure_args=[],
+        libjim=LIBJIM_FROM_APT,
+    ),
+]
+
+OPENOCD_VERSION_NAMES = [v.name for v in OPENOCD_VERSIONS]

--- a/tests_integration/openocd_version_info.py
+++ b/tests_integration/openocd_version_info.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import dataclass, field
+from typing import Optional
+
 
 REPO_OPENOCD_VANILLA = "https://github.com/openocd-org/openocd.git"
 REPO_OPENOCD_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
@@ -14,8 +16,8 @@ REPO_LIBJIM = "https://github.com/msteveb/jimtcl.git"
 class LibJimVersion:
     is_internal: bool = False
     is_from_apt: bool = False
-    repo: str | None = None
-    git_rev: str | None = None
+    repo: Optional[str] = None
+    git_rev: Optional[str] = None
     extra_configure_args: list[str] = field(default_factory=lambda: [])
 
 

--- a/tests_integration/openocd_version_info.py
+++ b/tests_integration/openocd_version_info.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-
 REPO_OPENOCD_VANILLA = "https://github.com/openocd-org/openocd.git"
 REPO_OPENOCD_RISCV = "https://github.com/riscv-collab/riscv-openocd.git"
 

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -14,17 +14,21 @@ def test_no_output(openocd_process):
         assert out == ""
 
 
-def test_with_output(openocd_process):
+def test_return(openocd_process):
     with PyOpenocdClient() as ocd:
         out = ocd.raw_cmd("return abcdef")
         assert out == "abcdef"
 
 
-def test_whitespace_trimmed(openocd_process):
+def test_return_with_whitespace(openocd_process, has_buggy_whitespace_trim):
     with PyOpenocdClient() as ocd:
         out = ocd.raw_cmd("return {  abc 4567 }")
-        # OpenOCD trims leading and trailing whitespace
-        assert out == "abc 4567"
+
+        if has_buggy_whitespace_trim:
+            assert out == "abc 4567"
+            pytest.xfail("known OpenOCD whitespace bug")
+        else:
+            assert out == "  abc 4567 "
 
 
 def test_nonexistent_cmd(openocd_process):
@@ -33,10 +37,17 @@ def test_nonexistent_cmd(openocd_process):
         assert out == 'invalid command name "nonexistent_cmd"'
 
 
-def test_capture(openocd_process):
+def test_echo_capture(openocd_process):
     with PyOpenocdClient() as ocd:
         out = ocd.raw_cmd("capture { echo {abcdef} }")
+        # "echo" appends \n at the end
         assert out == "abcdef\n"
+
+
+def test_echo_capture_whitespace(openocd_process):
+    with PyOpenocdClient() as ocd:
+        out = ocd.raw_cmd("capture { echo { 123 456 } }")
+        assert out == " 123 456 \n"
 
 
 def test_catch_success(openocd_process):
@@ -57,43 +68,71 @@ def test_catch_throw(openocd_process):
         assert int(out) == 22  # error code
 
 
+def _parse_out(out):
+    # "5 some text" -> (5, "some text")
+    parts = out.split(" ", maxsplit=1)
+    retcode = int(parts[0])
+    out = parts[1]
+    return int(parts[0]), parts[1]
+
+
 def test_catch_output_and_success(openocd_process):
     with PyOpenocdClient() as ocd:
         cmd = 'set RETCODE [ catch { version } OUT ]; return "$RETCODE $OUT" '
         out = ocd.raw_cmd(cmd)
-
-        parts = out.split(" ", maxsplit=1)
-        retcode = int(parts[0])
-        out = parts[1]
+        retcode, text = _parse_out(out)
 
         assert retcode == 0  # success code
-        assert "Open On-Chip Debugger" in out
+        assert "Open On-Chip Debugger" in text
+
+
+def test_catch_output_and_success_whitespace(openocd_process, has_buggy_whitespace_trim):
+    with PyOpenocdClient() as ocd:
+        cmd = 'set RETCODE [ catch { string repeat { a } 4 } OUT ]; return "$RETCODE $OUT" '
+        out = ocd.raw_cmd(cmd)
+        retcode, text = _parse_out(out)
+
+        assert retcode == 0  # success code
+
+        if has_buggy_whitespace_trim:
+            assert text == " a  a  a  a"
+            pytest.xfail("known OpenOCD whitespace bug")
+        else:
+            assert text == " a  a  a  a "
 
 
 def test_catch_output_and_error(openocd_process):
     with PyOpenocdClient() as ocd:
         cmd = 'set RETCODE [ catch { nonexistent_cmd } OUT; ]; return "$RETCODE $OUT" '
         out = ocd.raw_cmd(cmd)
-
-        parts = out.split(" ", maxsplit=1)
-        retcode = int(parts[0])
-        out = parts[1]
+        retcode, text = _parse_out(out)
 
         assert retcode != 0  # error code
-        assert "invalid command" in out
+        assert "invalid command" in text
 
 
 def test_catch_output_and_throw(openocd_process):
     with PyOpenocdClient() as ocd:
         cmd = 'set RETCODE [catch { throw 25 {my msg} } OUT;]; return "$RETCODE $OUT"'
         out = ocd.raw_cmd(cmd)
-
-        parts = out.split(" ", maxsplit=1)
-        retcode = int(parts[0])
-        out = parts[1]
+        retcode, text = _parse_out(out)
 
         assert retcode == 25  # error code
-        assert out == "my msg"
+        assert text == "my msg"
+
+
+def test_catch_output_and_throw_whitespace(openocd_process, has_buggy_whitespace_trim):
+    with PyOpenocdClient() as ocd:
+        cmd = 'set RETCODE [catch { throw 25 { my msg  } } OUT;]; return "$RETCODE $OUT"'
+        out = ocd.raw_cmd(cmd)
+        retcode, text = _parse_out(out)
+
+        assert retcode == 25  # error code
+        if has_buggy_whitespace_trim:
+            assert text == " my msg"
+            pytest.xfail("known OpenOCD whitespace bug")
+        else:
+            assert text == " my msg  "
 
 
 def test_raw_cmd_timeout_ok(openocd_process):

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -71,8 +71,6 @@ def test_catch_throw(openocd_process):
 def _parse_out(out):
     # "5 some text" -> (5, "some text")
     parts = out.split(" ", maxsplit=1)
-    retcode = int(parts[0])
-    out = parts[1]
     return int(parts[0]), parts[1]
 
 
@@ -86,9 +84,14 @@ def test_catch_output_and_success(openocd_process):
         assert "Open On-Chip Debugger" in text
 
 
-def test_catch_output_and_success_whitespace(openocd_process, has_buggy_whitespace_trim):
+def test_catch_output_and_success_whitespace(
+    openocd_process, has_buggy_whitespace_trim
+):
     with PyOpenocdClient() as ocd:
-        cmd = 'set RETCODE [ catch { string repeat { a } 4 } OUT ]; return "$RETCODE $OUT" '
+        cmd = (
+            "set RETCODE [catch { string repeat { a } 4 } OUT]; "
+            'return "$RETCODE $OUT"'
+        )
         out = ocd.raw_cmd(cmd)
         retcode, text = _parse_out(out)
 
@@ -123,7 +126,9 @@ def test_catch_output_and_throw(openocd_process):
 
 def test_catch_output_and_throw_whitespace(openocd_process, has_buggy_whitespace_trim):
     with PyOpenocdClient() as ocd:
-        cmd = 'set RETCODE [catch { throw 25 { my msg  } } OUT;]; return "$RETCODE $OUT"'
+        cmd = (
+            'set RETCODE [catch { throw 25 { my msg  } } OUT;]; return "$RETCODE $OUT"'
+        )
         out = ocd.raw_cmd(cmd)
         retcode, text = _parse_out(out)
 


### PR DESCRIPTION
In OpenOCD 0.13.0 [1], the "return" command was fixed so that it no longer performs an extra trim of whitespace from the beginning and end of the command output. Account for that in the integration tests.

[1] OpenOCD commit "93f16eed4, https://review.openocd.org/c/openocd/+/9084