### PR TITLE
Fix: Proper exception if OpenOCD closes the connection

### DIFF
--- a/src/py_openocd_client/baseclient.py
+++ b/src/py_openocd_client/baseclient.py
@@ -94,10 +94,26 @@ class _PyOpenocdBaseClient:
             raise ValueError("Timeout must be greater than zero")
         self._default_recv_timeout = timeout
 
-    def _check_no_premature_recvd_bytes(self) -> None:
+    def _check_connection_before_command(self) -> None:
         assert self._socket is not None
         rd, _, _ = select.select([self._socket], [], [], 0)  # Don't block, just poll
-        if len(rd) > 0:
+
+        if len(rd) == 0:
+            # The socket is not ready for recv() now, which is the expected state.
+            # Success.
+            return
+
+        # The socket is ready for recv(). This is an error.
+        # Find out what happened:
+        recvd_data = self._socket.recv(128)
+        if len(recvd_data) == 0:
+            # Empty received data means that the connection got closed by OpenOCD
+            # in the meanwhile.
+            raise OcdConnectionError("Connection closed by OpenOCD")
+        else:
+            # It looks like OpenOCD sent us some extra, unsolicited bytes (without us
+            # sending any command to OpenOCD). This is a violation of the communication
+            # protocol.
             raise OcdConnectionError(
                 "Received unexpected bytes from OpenOCD before "
                 "the command was even sent."
@@ -108,7 +124,7 @@ class _PyOpenocdBaseClient:
         assert self._socket is not None
 
         # Safety:
-        self._check_no_premature_recvd_bytes()
+        self._check_connection_before_command()
 
         data = raw_cmd.encode(self.CHARSET) + self.COMMAND_DELIMITER
         self._socket.settimeout(self.SEND_TIMEOUT)

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -165,7 +165,7 @@ def test_raw_cmd_shutdown(openocd_process):
 
         # Calling shutdown must cause the OpenOCD process to exit.
         # The command output must be empty.
-        assert ocd.raw_cmd("expr {1 + 2 + 3}") == "6"
+        assert ocd.raw_cmd("shutdown") == ""
 
         # Safety: Give OpenOCD little time to terminate, avoid races
         time.sleep(0.5)
@@ -175,7 +175,7 @@ def test_raw_cmd_shutdown(openocd_process):
 
         # Sending another command must cause a proper exception
         with pytest.raises(OcdConnectionError) as e:
-            ocd.raw_cmd("expr {4 + 5 + 6}")
+            ocd.raw_cmd("expr {1 + 2 + 3}")
 
         assert "Connection closed by OpenOCD" in str(e)
 

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: MIT
 
 import time
+
 import pytest
 
-from py_openocd_client import OcdCommandTimeoutError, OcdConnectionError, PyOpenocdClient
+from py_openocd_client import (
+    OcdCommandTimeoutError,
+    OcdConnectionError,
+    PyOpenocdClient,
+)
 
 
 def test_no_output(openocd_process):
@@ -170,8 +175,9 @@ def test_raw_cmd_shutdown(openocd_process):
         # Safety: Give OpenOCD little time to terminate, avoid races
         time.sleep(0.5)
 
-        assert openocd_process.poll() is not None, \
-            "OpenOCD did not terminate after shutdown command"
+        assert (
+            openocd_process.poll() is not None
+        ), "OpenOCD did not terminate after shutdown command"
 
         # Sending another command must cause a proper exception
         with pytest.raises(OcdConnectionError) as e:

--- a/tests_integration/test_integration_raw_cmd.py
+++ b/tests_integration/test_integration_raw_cmd.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 
+import time
 import pytest
 
-from py_openocd_client import OcdCommandTimeoutError, PyOpenocdClient
+from py_openocd_client import OcdCommandTimeoutError, OcdConnectionError, PyOpenocdClient
 
 
 def test_no_output(openocd_process):
@@ -153,3 +154,30 @@ def test_raw_cmd_timeout_exceeded(openocd_process):
 
         assert e.value.raw_cmd == "sleep 2000"
         assert e.value.timeout == 1.0
+
+
+def test_raw_cmd_shutdown(openocd_process):
+    with PyOpenocdClient() as ocd:
+
+        # Test that the connection works and commands are serviced
+        assert ocd.is_connected()
+        assert "On-Chip Debugger" in ocd.raw_cmd("version")
+
+        # Calling shutdown must cause the OpenOCD process to exit.
+        # The command output must be empty.
+        assert ocd.raw_cmd("expr {1 + 2 + 3}") == "6"
+
+        # Safety: Give OpenOCD little time to terminate, avoid races
+        time.sleep(0.5)
+
+        assert openocd_process.poll() is not None, \
+            "OpenOCD did not terminate after shutdown command"
+
+        # Sending another command must cause a proper exception
+        with pytest.raises(OcdConnectionError) as e:
+            ocd.raw_cmd("expr {4 + 5 + 6}")
+
+        assert "Connection closed by OpenOCD" in str(e)
+
+        # Due to the exception, we must be disconnected
+        assert not ocd.is_connected()

--- a/tests_unit/test_baseclient_errors.py
+++ b/tests_unit/test_baseclient_errors.py
@@ -87,20 +87,43 @@ def test_set_tcp_nodelay_error(socket_inst_mock):
     assert not ocd_base.is_connected()
 
 
+def test_remote_disconnect_before_sending_command(socket_inst_mock, select_mock):
+    ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+    ocd_base.connect()
+
+    # Pretend that the remote server (OpenOCD) closed the connection before
+    # we attempted to send the command
+    select_mock.return_value = [ocd_base._socket], [], []
+    socket_inst_mock.recv.side_effect = [b""]  # No data means closed connection
+
+    with pytest.raises(OcdConnectionError) as e:
+        ocd_base.raw_cmd("some_command")
+
+    assert "Connection closed by OpenOCD" in str(e)
+
+    socket_inst_mock.recv.assert_called_once()
+    socket_inst_mock.send.assert_not_called()
+
+    # Must be disconnected after an error
+    socket_inst_mock.close.assert_called_once()
+    assert not ocd_base.is_connected()
+
+
 def test_recv_extra_bytes_before_sending_command(socket_inst_mock, select_mock):
     ocd_base = _PyOpenocdBaseClient("localhost", 6666)
     ocd_base.connect()
 
-    # Pretend that some data arrived before the command
+    # Pretend that some data arrived before the command was even sent
     select_mock.return_value = [ocd_base._socket], [], []
+    socket_inst_mock.recv.side_effect = [b"unexpected recvd bytes"]
 
     with pytest.raises(OcdConnectionError) as e:
         ocd_base.raw_cmd("some_command")
 
     assert "Received unexpected bytes from OpenOCD" in str(e)
 
+    socket_inst_mock.recv.assert_called_once()
     socket_inst_mock.send.assert_not_called()
-    socket_inst_mock.recv.assert_not_called()
 
     # Must be disconnected after an error
     socket_inst_mock.close.assert_called_once()


### PR DESCRIPTION
If the Tcl session gets closed by OpenOCD, make sure that this gets detected when trying to send the next command, and a correct exception is provided to the user.