### PR TITLE
Diligent handling of socket exceptions

### DIFF
--- a/src/py_openocd_client/baseclient.py
+++ b/src/py_openocd_client/baseclient.py
@@ -167,7 +167,8 @@ class _PyOpenocdBaseClient:
             self._socket.settimeout(self.RECV_POLL_TIMEOUT)
         except OSError as e:
             raise OcdConnectionError(
-                "Could not receive a response from OpenOCD, failed to set socket timeout"
+                "Could not receive a response from OpenOCD, "
+                "failed to set socket timeout"
             ) from e
 
         time_start = time.time()

--- a/src/py_openocd_client/baseclient.py
+++ b/src/py_openocd_client/baseclient.py
@@ -103,9 +103,18 @@ class _PyOpenocdBaseClient:
             # Success.
             return
 
-        # The socket is ready for recv(). This is an error.
-        # Find out what happened:
-        recvd_data = self._socket.recv(128)
+        # The socket is ready for recv(). This is unexpected at this point
+        # and always means an error. Try receive from the socket to find out
+        # what happened:
+        try:
+            recvd_data = self._socket.recv(128)
+        except OSError as e:
+            # This is unlikely to happen: It would mean that the socket is ready
+            # for recv() but then recv() failed.
+            raise OcdConnectionError(
+                "Connection to OpenOCD broken for an unknown reason"
+            ) from e
+
         if len(recvd_data) == 0:
             # Empty received data means that the connection got closed by OpenOCD
             # in the meanwhile.
@@ -123,12 +132,27 @@ class _PyOpenocdBaseClient:
         assert self.is_connected()
         assert self._socket is not None
 
-        # Safety:
+        # Perform basic connection check before sending a command.
+        # Note that this is merely a safety/correctness check which itself
+        # does not guarantee that the subsequent send() and recv() calls
+        # will succeed.
         self._check_connection_before_command()
 
         data = raw_cmd.encode(self.CHARSET) + self.COMMAND_DELIMITER
-        self._socket.settimeout(self.SEND_TIMEOUT)
-        self._socket.send(data)
+
+        try:
+            self._socket.settimeout(self.SEND_TIMEOUT)
+        except OSError as e:
+            raise OcdConnectionError(
+                "Could not send a command to OpenOCD, failed to set socket timeout"
+            ) from e
+
+        try:
+            self._socket.send(data)
+        except OSError as e:
+            raise OcdConnectionError(
+                "Could not send a command to OpenOCD, socket error occurred"
+            ) from e
 
     def _do_recv_response(self, raw_cmd: str, timeout: Optional[float] = None) -> str:
         assert self.is_connected()
@@ -139,7 +163,12 @@ class _PyOpenocdBaseClient:
             timeout if timeout is not None else self._default_recv_timeout
         )
 
-        self._socket.settimeout(self.RECV_POLL_TIMEOUT)
+        try:
+            self._socket.settimeout(self.RECV_POLL_TIMEOUT)
+        except OSError as e:
+            raise OcdConnectionError(
+                "Could not receive a response from OpenOCD, failed to set socket timeout"
+            ) from e
 
         time_start = time.time()
         while time.time() < (time_start + effective_timeout):
@@ -147,6 +176,10 @@ class _PyOpenocdBaseClient:
                 d = self._socket.recv(self.RECV_BLOCK_SIZE)
             except socket.timeout:
                 continue
+            except OSError as e:
+                raise OcdConnectionError(
+                    "Could not receive a response from OpenOCD, socket error occurred"
+                ) from e
 
             if d == b"":
                 raise OcdConnectionError("Connection closed by OpenOCD")

--- a/tests_unit/test_baseclient_errors.py
+++ b/tests_unit/test_baseclient_errors.py
@@ -198,12 +198,18 @@ def test_raw_cmd_socket_settimeout_error_before_recv(socket_inst_mock):
     ocd_base = _PyOpenocdBaseClient("localhost", 6666)
     ocd_base.connect()
 
-    socket_inst_mock.settimeout.side_effect = [None, OSError("socket settimeout() failed")]
+    socket_inst_mock.settimeout.side_effect = [
+        None,
+        OSError("socket settimeout() failed"),
+    ]
 
     with pytest.raises(OcdConnectionError) as e:
         ocd_base.raw_cmd("some_cmd")
 
-    assert "Could not receive a response from OpenOCD, failed to set socket timeout" in str(e)
+    assert (
+        "Could not receive a response from OpenOCD, failed to set socket timeout"
+        in str(e)
+    )
 
     socket_inst_mock.send.assert_called_once()
     socket_inst_mock.recv.assert_not_called()

--- a/tests_unit/test_baseclient_errors.py
+++ b/tests_unit/test_baseclient_errors.py
@@ -176,6 +176,95 @@ def test_raw_cmd_connection_closed_by_openocd(socket_inst_mock):
     assert not ocd_base.is_connected()
 
 
+def test_raw_cmd_socket_settimeout_error_before_send(socket_inst_mock):
+    ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+    ocd_base.connect()
+
+    socket_inst_mock.settimeout.side_effect = [OSError("socket settimeout() failed")]
+
+    with pytest.raises(OcdConnectionError) as e:
+        ocd_base.raw_cmd("some_cmd")
+
+    assert "Could not send a command to OpenOCD, failed to set socket timeout" in str(e)
+
+    socket_inst_mock.settimeout.assert_called_once()
+    socket_inst_mock.send.assert_not_called()
+    socket_inst_mock.recv.assert_not_called()
+    socket_inst_mock.close.assert_called_once()
+    assert not ocd_base.is_connected()
+
+
+def test_raw_cmd_socket_settimeout_error_before_recv(socket_inst_mock):
+    ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+    ocd_base.connect()
+
+    socket_inst_mock.settimeout.side_effect = [None, OSError("socket settimeout() failed")]
+
+    with pytest.raises(OcdConnectionError) as e:
+        ocd_base.raw_cmd("some_cmd")
+
+    assert "Could not receive a response from OpenOCD, failed to set socket timeout" in str(e)
+
+    socket_inst_mock.send.assert_called_once()
+    socket_inst_mock.recv.assert_not_called()
+    socket_inst_mock.close.assert_called_once()
+    assert not ocd_base.is_connected()
+
+
+def test_raw_cmd_socket_send_error(socket_inst_mock):
+    ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+    ocd_base.connect()
+
+    socket_inst_mock.send.side_effect = OSError("socket send() failed")
+
+    with pytest.raises(OcdConnectionError) as e:
+        ocd_base.raw_cmd("some_cmd")
+
+    assert "Could not send a command to OpenOCD, socket error occurred" in str(e)
+
+    socket_inst_mock.send.assert_called_once()
+    socket_inst_mock.recv.assert_not_called()
+    socket_inst_mock.close.assert_called_once()
+    assert not ocd_base.is_connected()
+
+
+def test_raw_cmd_socket_recv_error_before_send(socket_inst_mock):
+    with mock.patch("select.select") as m:
+        m.return_value = [socket_inst_mock], [], []
+
+        ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+        ocd_base.connect()
+
+        socket_inst_mock.recv.side_effect = [OSError("socket recv() failed")]
+
+        with pytest.raises(OcdConnectionError) as e:
+            ocd_base.raw_cmd("some_cmd")
+
+        assert "Connection to OpenOCD broken for an unknown reason" in str(e)
+
+        socket_inst_mock.send.assert_not_called()
+        socket_inst_mock.recv.assert_called_once()
+        socket_inst_mock.close.assert_called_once()
+        assert not ocd_base.is_connected()
+
+
+def test_raw_cmd_socket_recv_error_after_send(socket_inst_mock):
+    ocd_base = _PyOpenocdBaseClient("localhost", 6666)
+    ocd_base.connect()
+
+    socket_inst_mock.recv.side_effect = [OSError("socket recv() failed")]
+
+    with pytest.raises(OcdConnectionError) as e:
+        ocd_base.raw_cmd("some_cmd")
+
+    assert "Could not receive a response from OpenOCD, socket error occurred" in str(e)
+
+    socket_inst_mock.send.assert_called_once()
+    socket_inst_mock.recv.assert_called_once()
+    socket_inst_mock.close.assert_called_once()
+    assert not ocd_base.is_connected()
+
+
 def test_raw_cmd_extra_bytes_after_delimiter(socket_inst_mock):
     ocd_base = _PyOpenocdBaseClient("localhost", 6666)
     ocd_base.connect()


### PR DESCRIPTION
Ensure that when a socket exception occurs in any socket call
(send, recv, settimeout):
    
- the exception is properly caught and presented to the user
  as OcdConnectionError,
    
- the connection to OpenOCD is closed (ocd.is_connected() becomes False).
